### PR TITLE
docs: add documentation about UUID and queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Zego Coding Style Guide
 
+This style guide serves to present a set of good and bad conventions with the objective of improving the overal code readibility and architecture. 
+At Zego we use python and javascript for backend and frontend development, this guide should ultimately define what we consider the best way to write the cleanest code for either of the languages and frameworks used within backend and frontend.
+
+
 - [JavaScript](/languages/JavaScript/index.md)
 - [Python](/languages/Python/index.md)
+- [Python architecture](/languages/Python/architecture.md)
 - [Commit messages](CommitMessages.md)

--- a/languages/Python/architecture.md
+++ b/languages/Python/architecture.md
@@ -14,7 +14,7 @@ There are a fair number of articles that explain why sequential ids might be an 
 
 ###### Why:
 - Avoids information disclosure
-- Stops entity enumeration
+- Stops entity enumeration -> [IDOR](https://medium.com/@woj_ciech/explaining-idor-in-almost-real-life-scenario-in-bug-bounty-program-c214008f8378)
 - Less prone to mistakes while querying DB
 
 Don't:

--- a/languages/Python/architecture.md
+++ b/languages/Python/architecture.md
@@ -20,6 +20,12 @@ There are a fair number of articles that explain why sequential ids might be an 
 Don't:
 ```python
 class Entity(models.Model):
+    # Django adds a sequential ID by default
+    ...
+```
+
+```python
+class Entity(models.Model):
     id = models.AutoField(primary_key=True)
 ```
 

--- a/languages/Python/architecture.md
+++ b/languages/Python/architecture.md
@@ -1,12 +1,8 @@
 # Python architecture
 
-- [Python architecture](#python-architecture)
-  - [General](#general)
-  - [Django](#django)
-    - [Use UUID instead of sequential IDs](#use-uuid-instead-of-sequential-ids)
-          - [Why:](#why)
-    - [Queries inside managers](#queries-inside-managers)
-          - [Why:](#why-1)
+- [General](#general)
+- [Django](#django)
+  - [Use UUID instead of sequential IDs](#use-uuid-instead-of-sequential-ids)
 
 
 ## General
@@ -30,65 +26,5 @@ class Entity(models.Model):
 Do:
 ```python
 class Entity(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4)
-```
-
-### Queries inside managers
-Django concept of a `Manager` is:
-> The interface through which database query operations are provided to Django models
-
-Even though the term `Manager` is as broad as it can be, we should follow the Django concept and define all of our queries inside the Manager set for a particular Model.
-
-###### Why:
-- Avoids duplication of queries
-- Easier to refactor code by not having to find all the dispersed queries if a field is changed or removed
-- Encapsulates Model logic close to the model
-- Easier to read
-
-Don't:
-```python
-# don't write random queries in the code
-Policy.objects.filter(
-  end_date__gte=tz_now(tz), product__enabled=True)
-```
-
-Do:
-```python
-# define the manager
-class PolicyManager(models.Manager):
-  def get_active_or_upcoming():
-    return self.get_queryset().filter(
-      end_date__gte=tz_now(tz), product__enabled=True
-    )
-
-# set the manager in the model
-class Policy(models.Model):
-  objects = PolicyManager()
-
-# and then use this wherever you want to
-Policy.objects.get_active_or_upcoming() 
-```
-
-Name of a manager query method should be descriptive of what the query is actually achieving, not how it is achieving it. e.g:
-
-Don't:
-```python
-def get_product_enabled_and_end_date_gte_today():
-  return self.get_queryset().filter(
-    end_date__gte=tz_now(tz), product__enabled=True
-  )
-```
-
-Do:
-```python
-def get_active_or_upcoming():
-  return self.get_queryset().filter(
-    end_date__gte=tz_now(tz), product__enabled=True
-  )
-```
-
-There is also no need to duplicate the name of the entity in the method name, so `get_active_or_upcoming_policy` can be just `get_active_or_upcoming`, remember that this should be called like so:
-
-```python
-Policy.objects.get_active_or_upcoming()
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
 ```

--- a/languages/Python/architecture.md
+++ b/languages/Python/architecture.md
@@ -1,0 +1,94 @@
+# Python architecture
+
+- [Python architecture](#python-architecture)
+  - [General](#general)
+  - [Django](#django)
+    - [Use UUID instead of sequential IDs](#use-uuid-instead-of-sequential-ids)
+          - [Why:](#why)
+    - [Queries inside managers](#queries-inside-managers)
+          - [Why:](#why-1)
+
+
+## General
+[work in progress]
+
+## Django
+### Use UUID instead of sequential IDs
+There are a fair number of articles that explain why sequential ids might be an issue but, to summarise:
+
+###### Why:
+- Avoids information disclosure
+- Stops entity enumeration
+- Less prone to mistakes while querying DB
+
+Don't:
+```python
+class Entity(models.Model):
+    id = models.AutoField(primary_key=True)
+```
+
+Do:
+```python
+class Entity(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4)
+```
+
+### Queries inside managers
+Django concept of a `Manager` is:
+> The interface through which database query operations are provided to Django models
+
+Even though the term `Manager` is as broad as it can be, we should follow the Django concept and define all of our queries inside the Manager set for a particular Model.
+
+###### Why:
+- Avoids duplication of queries
+- Easier to refactor code by not having to find all the dispersed queries if a field is changed or removed
+- Encapsulates Model logic close to the model
+- Easier to read
+
+Don't:
+```python
+# don't write random queries in the code
+Policy.objects.filter(
+  end_date__gte=tz_now(tz), product__enabled=True)
+```
+
+Do:
+```python
+# define the manager
+class PolicyManager(models.Manager):
+  def get_active_or_upcoming():
+    return self.get_queryset().filter(
+      end_date__gte=tz_now(tz), product__enabled=True
+    )
+
+# set the manager in the model
+class Policy(models.Model):
+  objects = PolicyManager()
+
+# and then use this wherever you want to
+Policy.objects.get_active_or_upcoming() 
+```
+
+Name of a manager query method should be descriptive of what the query is actually achieving, not how it is achieving it. e.g:
+
+Don't:
+```python
+def get_product_enabled_and_end_date_gte_today():
+  return self.get_queryset().filter(
+    end_date__gte=tz_now(tz), product__enabled=True
+  )
+```
+
+Do:
+```python
+def get_active_or_upcoming():
+  return self.get_queryset().filter(
+    end_date__gte=tz_now(tz), product__enabled=True
+  )
+```
+
+There is also no need to duplicate the name of the entity in the method name, so `get_active_or_upcoming_policy` can be just `get_active_or_upcoming`, remember that this should be called like so:
+
+```python
+Policy.objects.get_active_or_upcoming()
+```


### PR DESCRIPTION
Adds `Use UUID instead of sequential IDs` ~~and `Queries inside managers`~~ to architecture style guide

~~Regarding the names of the Manager methods we could define something as well, at least trying to identify if a query will return one or many results.~~
~~`get_all...()`, `get_one...()`, ..~~