### PR TITLE
docs(react): avoid hard-coding colours

### DIFF
--- a/languages/JavaScript/react.md
+++ b/languages/JavaScript/react.md
@@ -48,3 +48,33 @@ Use `<button>` elements for actions that don't perform a navigation and/or rely 
 ### 🤖 ESLint Rule: **eslint-plugin-jsx-a11y**
 
 Plugin available: [eslint-plugin-jsx-a11y](https://www.npmjs.com/package/eslint-plugin-jsx-a11y) that covers most of these rules.
+
+## Avoid hard-coding colours in React
+
+Throughout the code, avoid hard-coding in colours that can be found in `website-next/src/theme.js`. Instead import in and use helper functions such as `primaryColor, disabledColor` to use a specific colour. This excludes any custom colours that design may include.
+
+### ℹ️ Why: **Ease of Future Colour Changes and Decrease Human Error**
+
+In the event, the colour palette changes or design wants to make a change to a colour, it will make for a clean change in only the theme file and avoid an extensive refactor to trace all usages of that particular colour(s). It will also help to decrease human error of typing in a wrong hex colour.
+
+### ❓ When: **Any changes to webpages that include new or updated colours**
+
+These new or updated colours are typically found in Figma files and / or the acceptance criteria for a ticket.
+
+### ❌ Don't: **Hard-code colours**
+
+Avoid hard-coding colours that are found in the `website-next/src/theme.js` file.
+
+```jsx
+<button css={{backgroundColor: '#371987'}}>Click Me</button>
+```
+
+### ✅ Do: **Use the helper functions available in the `website-next/src/theme.js` file**
+
+For example,
+
+```jsx
+import { primaryColor } from '@zego/theme.js'
+
+<button css={{backgroundColor: primaryColor(11)}}>Click Me</button>
+```


### PR DESCRIPTION
- Add rule to avoid hard-coding in colours

- This came up as we were updating the colour palette and realised how many places we had been hard-coding in colours